### PR TITLE
Feature/item expanded page

### DIFF
--- a/src/Components/App.js
+++ b/src/Components/App.js
@@ -1,3 +1,4 @@
+import React, { useEffect, useState } from "react";
 import { useQuery, gql } from "@apollo/client";
 import "./NavBar";
 import NavBar from "./NavBar";
@@ -11,12 +12,21 @@ import ItemExpanded from "./ItemExpanded";
 import Login from "./Login";
 import NoMatch from "./NoMatch";
 
+import response from "../data/allItems.json";
+
 function App() {
+
+  const [itemData, setItemData] = useState([]);
+   
+  useEffect(() => {
+     setItemData(response.data.getItems);
+  }, []);
+
   return (
     <main>
       <NavBar />
       <Routes>
-        <Route exact path="/" element={<LandingPage />} />
+        <Route exact path="/" element={<LandingPage  itemData={itemData} />} />
         <Route exact path="about" element={<AboutPage />} />
         <Route exact path="profile" element={<UserProfile />} />
         <Route exact path="contribution" element={<Form />} />

--- a/src/Components/App.js
+++ b/src/Components/App.js
@@ -22,15 +22,19 @@ function App() {
      setItemData(response.data.getItems);
   }, []);
 
+  const findItem = (id) => {  
+    return itemData.find(item => item.id === id)
+  }
+
   return (
     <main>
       <NavBar />
       <Routes>
-        <Route exact path="/" element={<LandingPage  itemData={itemData} />} />
+        <Route exact path="/" element={<LandingPage itemData={itemData} />} />
         <Route exact path="about" element={<AboutPage />} />
         <Route exact path="profile" element={<UserProfile />} />
         <Route exact path="contribution" element={<Form />} />
-        <Route exact path="craft/:craftId" element={<ItemExpanded />} />
+        <Route exact path="craft/:craftId" element={<ItemExpanded findItem={findItem} />} />
         {/* <Route exact path="confirmation" element={} /> */}
         <Route exact path="login" element={<Login />} />
         <Route path="*" element={<NoMatch />} />

--- a/src/Components/ItemCard.js
+++ b/src/Components/ItemCard.js
@@ -9,9 +9,9 @@ const ItemCard = ({ name, amount, id }) => {
             <ItemCardSection className="item-card">
                 <ItemCardImg className="stock-img" src={require("../assets/myrlene-numa-SnITZTTeJVE-unsplash.jpg")} alt="craft-item" />
                 <ItemBoxDiv>
-                        <ItemH4>{name}</ItemH4>
-                        <ItemP>Amount: {amount}</ItemP>
-                        <ItemP>Crafty Joe</ItemP>
+                    <ItemH4>{name}</ItemH4>
+                    <ItemP>Amount: {amount}</ItemP>
+                    <ItemP>Crafty Joe</ItemP>
                 </ItemBoxDiv>
             </ItemCardSection>
         </Link>

--- a/src/Components/ItemCard.js
+++ b/src/Components/ItemCard.js
@@ -1,21 +1,24 @@
+import { isNonEmptyArray } from "@apollo/client/utilities";
 import React from "react";
+import { Link } from "react-router-dom";
 import styled from 'styled-components';
 
 const ItemCard = ({ name, amount, id }) => {
     return (
-        <ItemCardSection className="item-card">
-           <ItemCardImg className="stock-img" src={require("../assets/myrlene-numa-SnITZTTeJVE-unsplash.jpg")} alt="craft-item" />
-           <ItemBoxDiv>
-                <ItemH4>{name}</ItemH4>
-                <ItemP>Amount: {amount}</ItemP>
-                <ItemP>Crafty Joe</ItemP>
-           </ItemBoxDiv>
-        </ItemCardSection>
+        <Link style={{textDecoration: "none"}} to={`/craft/${id}`}>
+            <ItemCardSection className="item-card">
+                <ItemCardImg className="stock-img" src={require("../assets/myrlene-numa-SnITZTTeJVE-unsplash.jpg")} alt="craft-item" />
+                <ItemBoxDiv>
+                        <ItemH4>{name}</ItemH4>
+                        <ItemP>Amount: {amount}</ItemP>
+                        <ItemP>Crafty Joe</ItemP>
+                </ItemBoxDiv>
+            </ItemCardSection>
+        </Link>
     );
 }
 
 export default ItemCard;
-
 
 const ItemCardImg = styled.img`
     width: 200px;

--- a/src/Components/ItemCard.js
+++ b/src/Components/ItemCard.js
@@ -1,7 +1,7 @@
 import React from "react";
 import styled from 'styled-components';
 
-const ItemCard = ({ name, amount }) => {
+const ItemCard = ({ name, amount, id }) => {
     return (
         <ItemCardSection className="item-card">
            <ItemCardImg className="stock-img" src={require("../assets/myrlene-numa-SnITZTTeJVE-unsplash.jpg")} alt="craft-item" />

--- a/src/Components/ItemContainer.js
+++ b/src/Components/ItemContainer.js
@@ -2,11 +2,8 @@ import styled from 'styled-components';
 import React from "react";
 import ItemCard from './ItemCard';
 
-import response from "../data/allItems.json"
+const ItemContainer = ({ itemData }) => {
 
-const ItemContainer = () => {
-
-   const itemData = response.data.getItems;
    const items = itemData.map(item => {
       return (
          <ItemCard

--- a/src/Components/ItemContainer.js
+++ b/src/Components/ItemContainer.js
@@ -31,7 +31,6 @@ const ItemContainerSection = styled.section`
 padding: 60px;
 display: grid;
 grid-template-columns: repeat(2, 1fr);
-background: #F4ECDD;
 gap: 60px;
 justify-items: center;
 align-items: center;

--- a/src/Components/ItemContainer.js
+++ b/src/Components/ItemContainer.js
@@ -11,6 +11,7 @@ const ItemContainer = () => {
       return (
          <ItemCard
             key={item.id}
+            id={item.id}
             name={item.name}
             amount={item.amount}
          />

--- a/src/Components/ItemExpanded.js
+++ b/src/Components/ItemExpanded.js
@@ -9,13 +9,13 @@ const ItemExpanded = () => {
                 <ItemExpandedImg className="item-image-large" src={require("../assets/myrlene-numa-SnITZTTeJVE-unsplash.jpg")} alt=""/>
             </ItemImgDiv>
             <ItemExpandedDiv>
-                <P>Art Supplies</P>
+                <CategoryP>Art Supplies</CategoryP>
                 <TitleAmountDiv>
                     <H2>Name of a Craft Here</H2>
-                    <P>Amount: 5?</P>
+                    <AmountP>Amount: 500</AmountP>
                 </TitleAmountDiv>
-                <P>Some description about the item that is probably pretty large I would imagine. What really can be considered 'long' though, you know? Anyways, here's some filler.   </P>
-                <P>Crafty Joe</P>
+                <DescP>Some description about the item that is probably pretty large I would imagine. What really can be considered 'long' though, you know? Anyways, here's some filler. Some say it never ends, but it certainly does. Infact, I think it ends riiight about here.</DescP>
+                <NameP>Crafty Joe</NameP>
                 <button className="contact-button"><a href="mailto:someone@example.com">Contact Crafter</a></button>
             </ItemExpandedDiv>
         </ItemExpandedSection>
@@ -25,17 +25,38 @@ const ItemExpanded = () => {
 export default ItemExpanded
 
 const ItemExpandedImg = styled.img`
-    width: 200px;
-    max-height: 200px;
+    width: 80%;
+    max-height: 500px;
     border-radius: 25px;
+    box-shadow: 20px 20px 0px #AD92C0;
 `;
 
 const H2 = styled.h2`
     color: #AD92C0;
 `;
 
-const P = styled.p`
-    color: #AD92C0;
+const DescP = styled.p`
+    color: #A18E96;
+    font-weight: bold;
+    max-width: 80%;
+`
+const NameP = styled.p`
+    color: #A18E96;
+    font-weight: bold;
+`
+
+const CategoryP = styled.p`
+    font-size: 16pt;
+    margin: 0;
+    color: #A18E96;
+    font-weight: bold;
+`
+
+const AmountP = styled.p`
+    font-size: 14pt;
+    color: #A18E96;
+    font-weight: bold;
+    margin-left: 20px;
 `
 
 const ItemExpandedSection = styled.section`
@@ -43,14 +64,14 @@ const ItemExpandedSection = styled.section`
 `;
 
 const TitleAmountDiv = styled.div`
-    width: 50%;
+    width: 70%;
     display: flex;
     justify-content: space-between;
     align-items: center;
 `;
 
 const ItemExpandedDiv = styled.div`
-    border: solid black 2px;
+
     width: 50vw;
     display: flex;
     justify-content: center;
@@ -59,7 +80,7 @@ const ItemExpandedDiv = styled.div`
 `;
 
 const ItemImgDiv = styled.div`
-    border: solid black 2px;
+
     width: 50vw;
     display: flex;
     justify-content: center;

--- a/src/Components/ItemExpanded.js
+++ b/src/Components/ItemExpanded.js
@@ -3,37 +3,34 @@ import { useParams } from "react-router-dom";
 import styled from 'styled-components';
 import Button from "./Button";
 
-import response from "../data/allItems.json";
-
-const ItemExpanded = () => {
+const ItemExpanded = ({ findItem }) => {
 
     const { craftId } = useParams()
 
     const [item, setItem] = useState({})
 
     useEffect(() => {
-        const findItem = (id) => {
-            return response.data.getItems.find(item => item.id === id)
-        }
-
         setItem(findItem(craftId))
-    },[])
+    },[item])
 
     return (
         <ItemExpandedSection className="item-expanded">
-            <ItemImgDiv>
-                <ItemExpandedImg className="item-image-large" src={require("../assets/myrlene-numa-SnITZTTeJVE-unsplash.jpg")} alt=""/>
-            </ItemImgDiv>
-            <ItemExpandedDiv>
-                <CategoryP>{item.category}</CategoryP>
-                <TitleAmountDiv>
-                    <H2>{item.name}</H2>
-                    <AmountP>Amount: {item.amount}</AmountP>
-                </TitleAmountDiv>
-                <DescP>{item.description}</DescP>
-                {/* <button className="contact-button"><a href="mailto:someone@example.com">Contact Crafter</a></button> */}
-                <Button name="Contact Crafter" link="" />
-            </ItemExpandedDiv>
+            {item ? <>
+                <ItemImgDiv>
+                    <ItemExpandedImg className="item-image-large" src={require("../assets/myrlene-numa-SnITZTTeJVE-unsplash.jpg")} alt=""/>
+                </ItemImgDiv>
+                <ItemExpandedDiv>
+                    <CategoryP>{item.category}</CategoryP>
+                    <TitleAmountDiv>
+                        <H2>{item.name}</H2>
+                        <AmountP>Amount: {item.amount}</AmountP>
+                    </TitleAmountDiv>
+                    <DescP>{item.description}</DescP>
+                    {/* <button className="contact-button"><a href="mailto:someone@example.com">Contact Crafter</a></button> */}
+                    <Button name="Contact Crafter" link="" />
+                </ItemExpandedDiv>
+            </>
+            : <h1>Loading...</h1>}
         </ItemExpandedSection>
     )
 }

--- a/src/Components/ItemExpanded.js
+++ b/src/Components/ItemExpanded.js
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from "react";
 import { useParams } from "react-router-dom";
 import styled from 'styled-components';
+import Button from "./Button";
 
 import response from "../data/allItems.json";
 
@@ -30,8 +31,8 @@ const ItemExpanded = () => {
                     <AmountP>Amount: {item.amount}</AmountP>
                 </TitleAmountDiv>
                 <DescP>{item.description}</DescP>
-                <NameP>Crafty Joe</NameP>
-                <button className="contact-button"><a href="mailto:someone@example.com">Contact Crafter</a></button>
+                {/* <button className="contact-button"><a href="mailto:someone@example.com">Contact Crafter</a></button> */}
+                <Button name="Contact Crafter" link="" />
             </ItemExpandedDiv>
         </ItemExpandedSection>
     )
@@ -62,7 +63,7 @@ const NameP = styled.p`
 
 const CategoryP = styled.p`
     font-size: 16pt;
-    margin: 0;
+    margin-bottom: 0;
     color: #A18E96;
     font-weight: bold;
 `

--- a/src/Components/ItemExpanded.js
+++ b/src/Components/ItemExpanded.js
@@ -3,14 +3,66 @@ import styled from 'styled-components';
 
 
 const ItemExpanded = () => {
-    <section className="item-expanded">
-        <img className="item-image-large" src="" alt=""/>
-        <h2>Title</h2>
-        <h3>amount</h3>
-        <p>description</p>
-        <p>crafter</p>
-        <button className="contact-button"><a href="mailto:someone@example.com">Contact Crafter</a></button>
-    </section>
+    return (
+        <ItemExpandedSection className="item-expanded">
+            <ItemImgDiv>
+                <ItemExpandedImg className="item-image-large" src={require("../assets/myrlene-numa-SnITZTTeJVE-unsplash.jpg")} alt=""/>
+            </ItemImgDiv>
+            <ItemExpandedDiv>
+                <P>Art Supplies</P>
+                <TitleAmountDiv>
+                    <H2>Name of a Craft Here</H2>
+                    <P>Amount: 5?</P>
+                </TitleAmountDiv>
+                <P>Some description about the item that is probably pretty large I would imagine. What really can be considered 'long' though, you know? Anyways, here's some filler.   </P>
+                <P>Crafty Joe</P>
+                <button className="contact-button"><a href="mailto:someone@example.com">Contact Crafter</a></button>
+            </ItemExpandedDiv>
+        </ItemExpandedSection>
+    )
 }
 
 export default ItemExpanded
+
+const ItemExpandedImg = styled.img`
+    width: 200px;
+    max-height: 200px;
+    border-radius: 25px;
+`;
+
+const H2 = styled.h2`
+    color: #AD92C0;
+`;
+
+const P = styled.p`
+    color: #AD92C0;
+`
+
+const ItemExpandedSection = styled.section`
+    display: flex;
+`;
+
+const TitleAmountDiv = styled.div`
+    width: 50%;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+`;
+
+const ItemExpandedDiv = styled.div`
+    border: solid black 2px;
+    width: 50vw;
+    display: flex;
+    justify-content: center;
+    align-items: flex-start;
+    flex-direction: column;
+`;
+
+const ItemImgDiv = styled.div`
+    border: solid black 2px;
+    width: 50vw;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    flex-direction: column;
+`;

--- a/src/Components/ItemExpanded.js
+++ b/src/Components/ItemExpanded.js
@@ -71,7 +71,7 @@ const AmountP = styled.p`
     font-size: 14pt;
     color: #A18E96;
     font-weight: bold;
-    margin-left: 20px;
+    margin-left: 50px;
 `
 
 const ItemExpandedSection = styled.section`
@@ -81,7 +81,6 @@ const ItemExpandedSection = styled.section`
 const TitleAmountDiv = styled.div`
     width: 70%;
     display: flex;
-    justify-content: space-between;
     align-items: center;
 `;
 

--- a/src/Components/ItemExpanded.js
+++ b/src/Components/ItemExpanded.js
@@ -1,20 +1,35 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
+import { useParams } from "react-router-dom";
 import styled from 'styled-components';
 
+import response from "../data/allItems.json";
 
 const ItemExpanded = () => {
+
+    const { craftId } = useParams()
+
+    const [item, setItem] = useState({})
+
+    useEffect(() => {
+        const findItem = (id) => {
+            return response.data.getItems.find(item => item.id === id)
+        }
+
+        setItem(findItem(craftId))
+    },[])
+
     return (
         <ItemExpandedSection className="item-expanded">
             <ItemImgDiv>
                 <ItemExpandedImg className="item-image-large" src={require("../assets/myrlene-numa-SnITZTTeJVE-unsplash.jpg")} alt=""/>
             </ItemImgDiv>
             <ItemExpandedDiv>
-                <CategoryP>Art Supplies</CategoryP>
+                <CategoryP>{item.category}</CategoryP>
                 <TitleAmountDiv>
-                    <H2>Name of a Craft Here</H2>
-                    <AmountP>Amount: 500</AmountP>
+                    <H2>{item.name}</H2>
+                    <AmountP>Amount: {item.amount}</AmountP>
                 </TitleAmountDiv>
-                <DescP>Some description about the item that is probably pretty large I would imagine. What really can be considered 'long' though, you know? Anyways, here's some filler. Some say it never ends, but it certainly does. Infact, I think it ends riiight about here.</DescP>
+                <DescP>{item.description}</DescP>
                 <NameP>Crafty Joe</NameP>
                 <button className="contact-button"><a href="mailto:someone@example.com">Contact Crafter</a></button>
             </ItemExpandedDiv>

--- a/src/Components/LandingPage.js
+++ b/src/Components/LandingPage.js
@@ -1,8 +1,17 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
 import styled from "styled-components";
 import ItemContainer from "./ItemContainer";
 
+import response from "../data/allItems.json";
+
 const LandingPage = () => {
+
+  const [itemData, setItemData] = useState([]);
+   
+  useEffect(() => {
+     setItemData(response.data.getItems);
+  }, []);
+
   return (
     <LandingPageSection className="landing-page">
       <LandingImage
@@ -10,7 +19,7 @@ const LandingPage = () => {
         src={require("../assets/bannerImage.png")}
         alt="crafts-in-action"
       />
-      <ItemContainer />
+      <ItemContainer itemData={itemData} />
     </LandingPageSection>
   );
 };

--- a/src/Components/LandingPage.js
+++ b/src/Components/LandingPage.js
@@ -1,16 +1,8 @@
-import React, { useEffect, useState } from "react";
+import React from "react";
 import styled from "styled-components";
 import ItemContainer from "./ItemContainer";
 
-import response from "../data/allItems.json";
-
-const LandingPage = () => {
-
-  const [itemData, setItemData] = useState([]);
-   
-  useEffect(() => {
-     setItemData(response.data.getItems);
-  }, []);
+const LandingPage = ({ itemData }) => {
 
   return (
     <LandingPageSection className="landing-page">


### PR DESCRIPTION
## What was changed:
- Adds ItemExpanded page
- App now holds state for item data
- App passes down item data as props

## Explain the reason for changes:
- Move state to App to allow for single query of data
- Made single page to copy wireframe

## Link to issue:
closes #10 
closes #16